### PR TITLE
Crawl Pushsum page parallel

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -51,8 +51,8 @@ var Commands = map[string]map[string]string{
 	},
 	"推噓文數相關": {
 		"新增(推/噓)文數 看板 總數": "通知推或噓文數",
-		"範例":    "新增推文數 joke,beauty 10",
-		"歸零即刪除": "新增噓文數 joke 0",
+		"範例":              "新增推文數 joke,beauty 10",
+		"歸零即刪除":           "新增噓文數 joke 0",
 	},
 	"推文相關": {
 		"新增推文 網址": "新增推文追蹤",
@@ -459,7 +459,7 @@ func checkArticleExist(boardName, articleCode string) bool {
 }
 
 func initialArticle(a article.Article) error {
-	a, err := crawler.BuildArticle(a.Board, a.Code)
+	a, err := crawler.FetchArticle(a.Board, a.Code)
 	if err != nil {
 		return err
 	}

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -47,8 +47,8 @@ func CurrentPage(board string) (int, error) {
 	return 0, errors.New("Parse Currenect Page Error")
 }
 
-// BuildArticles makes board's index articles to a article slice
-func BuildArticles(board string, page int) (articles article.Articles, err error) {
+// FetchArticles makes board's index articles to a article slice
+func FetchArticles(board string, page int) (articles article.Articles, err error) {
 	reqURL := makeBoardURL(board, page)
 	htmlNodes, err := fetchHTML(reqURL)
 	if err != nil {
@@ -116,8 +116,8 @@ func isLastArticleBlock(articleBlock *html.Node) bool {
 	return false
 }
 
-// BuildArticle build article object from html
-func BuildArticle(board, articleCode string) (article.Article, error) {
+// FetchArticle build article object from html
+func FetchArticle(board, articleCode string) (article.Article, error) {
 	reqURL := makeArticleURL(board, articleCode)
 	htmlNodes, err := fetchHTML(reqURL)
 	if err != nil {

--- a/crawler/crawler_test.go
+++ b/crawler/crawler_test.go
@@ -17,7 +17,7 @@ func BenchmarkCurrentPage(b *testing.B) {
 
 func BenchmarkBuildArticles(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		BuildArticles("lol", 9697)
+		FetchArticles("lol", 9697)
 	}
 }
 
@@ -160,7 +160,7 @@ func TestBuildArticles(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotArticles, err := BuildArticles(tt.args.board, tt.args.page)
+			gotArticles, err := FetchArticles(tt.args.board, tt.args.page)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildArticles() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -209,7 +209,7 @@ func TestBuildArticle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildArticle(tt.args.board, tt.args.articleCode)
+			got, err := FetchArticle(tt.args.board, tt.args.articleCode)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildArticle() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/meifamily/ptt-alertor
 
+go 1.15
+
 require (
 	github.com/PuerkitoBio/goquery v0.0.0-20170520194520-2dc93891ab3b // indirect
 	github.com/alicebob/miniredis v0.0.0-20171207150240-955f929b3a68

--- a/jobs/commentchecker.go
+++ b/jobs/commentchecker.go
@@ -84,7 +84,7 @@ func (cc commentChecker) Run() {
 
 func (cc commentChecker) checkComments(code string, ach chan article.Article) {
 	a := new(article.Article).Find(code)
-	new, err := crawler.BuildArticle(a.Board, a.Code)
+	new, err := crawler.FetchArticle(a.Board, a.Code)
 	if _, ok := err.(crawler.URLNotFoundError); ok {
 		cc.destroyComments(a)
 	}

--- a/jobs/pushsumchecker.go
+++ b/jobs/pushsumchecker.go
@@ -118,7 +118,7 @@ func (psc pushSumChecker) crawlArticles(ba BoardArticles, baCh chan BoardArticle
 
 Page:
 	for page := currentPage; page > 0; page-- {
-		articles, _ := crawler.BuildArticles(ba.board, page)
+		articles, _ := crawler.FetchArticles(ba.board, page)
 		for i := len(articles) - 1; i > 0; i-- {
 			a := articles[i]
 			if a.ID == 0 {

--- a/main.go
+++ b/main.go
@@ -156,9 +156,7 @@ func startJobs() {
 func init() {
 	// for initial app
 	// jobs.NewPushSumKeyReplacer().Run()
-	jobs.NewMigrateBoard(map[string]string{
-		"arenamofvalor": "arenaofvalor",
-	}).Run()
+	// jobs.NewMigrateBoard(map[string]string{"": ""}).Run()
 	// jobs.NewTop().Run()
 	// jobs.NewCacheCleaner().Run()
 	// jobs.NewGenerator().Run()

--- a/models/board/board.go
+++ b/models/board/board.go
@@ -115,7 +115,7 @@ func (bd Board) FetchArticles() (articles article.Articles) {
 			return
 		}
 		log.WithField("board", bd.Name).WithError(err).Error("RSS Parse Failed, Switch to HTML Crawler")
-		articles, err = crawler.BuildArticles(bd.Name, -1)
+		articles, err = crawler.FetchArticles(bd.Name, -1)
 		if err != nil {
 			log.WithField("board", bd.Name).WithError(err).Error("HTML Parse Failed")
 		}


### PR DESCRIPTION
Found there are 4 thousans pushsum boards need to check, made it parallel to accelerate speed.

if useless, may need to clean this user's subscribe, he subscribe 4132 pushsum dashbords..
https://github.com/meifamily/ptt-alertor/wiki/2020-11-28-CPU-Drop-down