### PR TITLE
Fix Redundant Pushsum Base and Bench key to Reduce DB Storage

### DIFF
--- a/jobs/pushsumkeyreplacer.go
+++ b/jobs/pushsumkeyreplacer.go
@@ -12,7 +12,7 @@ func NewPushSumKeyReplacer() *PushSumKeyReplacer {
 }
 
 func (r PushSumKeyReplacer) Run() {
-	if err := pushsum.ReplaceBaseKeys(); err != nil {
+	if err := pushsum.ReplaceBenchKeys(); err != nil {
 		log.WithError(err).Error("Replace Pushsum Key Failed")
 	}
 	log.Info("Replace Pushsum Key Done")


### PR DESCRIPTION
Redis storage exhausted due to too many pushsum article need to check, bench key(record articles which has been notifed last week) will replace base key (record articles which has been notifed this week) in the weekend, so the storage will be released.

![image](https://user-images.githubusercontent.com/6241603/119256164-e5b09700-bbf1-11eb-96ea-eecf4fb14add.png)

After discuss, @scottxxx666 suggest compare articles with base and bench together to reduce storage.